### PR TITLE
Fix: Copyright License and add script to update tag

### DIFF
--- a/.github/workflows/reusable-copyright-license-check.yml
+++ b/.github/workflows/reusable-copyright-license-check.yml
@@ -14,18 +14,29 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Full history so we can diff properly
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0   # Full history so we can diff properly.
+                                  # On pull_request events, actions/checkout fetches
+                                  # refs/pull/N/merge whose parents are base.sha and
+                                  # head.sha — both are already present after this step.
+         
  
-      - name: Add PR base repo as remote and fetch it
+      - name: Get base and head SHAs (from event payload, no token needed)
+        id: shas
         run: |
-          git remote add upstream https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git
-          git fetch upstream
- 
-      - name: Generate final patch between base and head
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          
+          echo "Base SHA: ${BASE_SHA}"
+          echo "Head SHA: ${HEAD_SHA}"
+          
+          echo "base_sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate patch between base and head
         run: |
-          git diff upstream/${{ github.event.pull_request.base.ref }} > pr.patch
+          git diff "${{ steps.shas.outputs.base_sha }}" \
+                   "${{ steps.shas.outputs.head_sha }}" \
+                   > pr.patch
           head -n 100 pr.patch
 
       - name: Run Copyright License Check Action

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,0 +1,45 @@
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to create/update tags
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Parse version and update major tag
+        run: |
+          FULL_TAG="${{ github.event.release.tag_name }}"
+          echo "Release tag : ${FULL_TAG}"
+
+          # Only process tags that match strict semver: vX.Y.Z
+          if [[ ! "${FULL_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::warning::Tag '${FULL_TAG}' is not semver (vX.Y.Z) — skipping major tag update."
+            exit 0
+          fi
+
+          # Extract major tag: v2.0.1 → v2  |  v10.3.0 → v10
+          # ${FULL_TAG%%.*} strips everything from the first '.' onward
+          MAJOR_TAG="${FULL_TAG%%.*}"
+          echo "Major tag   : ${MAJOR_TAG}"
+
+          # Determine whether this is a new major tag or an update
+          if git ls-remote --tags origin "${MAJOR_TAG}" | grep -q "${MAJOR_TAG}"; then
+            echo "Action      : UPDATE ${MAJOR_TAG} → ${FULL_TAG}"
+          else
+            echo "Action      : CREATE ${MAJOR_TAG} (new major release)"
+          fi
+
+          # Force-create or force-update the major tag to point to this
+          # release's commit SHA (same commit the full version tag points to).
+          git tag -f "${MAJOR_TAG}" "${{ github.sha }}"
+          git push origin "${MAJOR_TAG}" --force
+
+          echo "✓ ${MAJOR_TAG} now points to ${{ github.sha }} (${FULL_TAG})"


### PR DESCRIPTION
- Refactor reusable-copyright-license-check.yml to use explicit base/head SHAs from the PR event payload instead of fetching a remote upstream branch. This removes the dependency on a write-capable token and avoids issues with fork-based PRs where the upstream remote fetch could fail.

- Add update-major-tag.yml: a new workflow that automatically force-updates the floating major version tag (e.g. v2) to point to the latest semver release commit (e.g. v2.1.0) whenever a GitHub Release is published.